### PR TITLE
scope.c: add missing include for recent kernels

### DIFF
--- a/module/scope.c
+++ b/module/scope.c
@@ -11,6 +11,7 @@
 #include <linux/kthread.h>
 #include <linux/spinlock.h>
 #include <linux/string.h>
+#include <linux/uaccess.h>
 #include <linux/wait.h>
 #include <asm/uaccess.h>
 #include "scopecmd.h"


### PR DESCRIPTION
Recent Linux kernels need this extra include to avoid the
"implicit declaration of copy_to_user" compile error.